### PR TITLE
feat: example of how concerns can be used to reduce code repetition

### DIFF
--- a/app/models/concerns/has_slugged_title.rb
+++ b/app/models/concerns/has_slugged_title.rb
@@ -1,0 +1,12 @@
+module HasSluggedTitle
+  extend ActiveSupport::Concern
+
+  included do
+    extend FriendlyId
+    friendly_id :title, use: :slugged
+  end
+
+  def should_generate_new_friendly_id?
+    title_changed?
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,3 @@
 class Post < ActiveRecord::Base
-  extend FriendlyId
-  friendly_id :title, use: :slugged
-
-  def should_generate_new_friendly_id?
-    title_changed?
-  end
+  include HasSluggedTitle
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -1,12 +1,7 @@
 class Recipe < ActiveRecord::Base
-  extend FriendlyId
+  include HasSluggedTitle
   belongs_to :category
-  friendly_id :title, use: :slugged
   scope :original, -> { where(recipe_url: '') }
-
-  def should_generate_new_friendly_id?
-    title_changed?
-  end
 
   def original?
     self.recipe_url.blank?

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -3,11 +3,9 @@
 one:
   title: MyString
   description: MyText
-  preparation: MyText
-  category_id: 
+  category_id:
 
 two:
   title: MyString
   description: MyText
-  preparation: MyText
-  category_id: 
+  category_id:

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,8 @@
 # model remove the '{}' from the fixture names and add the columns immediately
 # below each fixture, per the syntax in the comments below
 #
-one: {}
+#one: {}
 # column: value
 #
-two: {}
+#two: {}
 #  column: value

--- a/test/models/concerns/has_slugged_title_spec.rb
+++ b/test/models/concerns/has_slugged_title_spec.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class Concerns::HasSluggedTitleTest < ActiveSupport::TestCase
+  test 'the concern extends FriendlyId' do
+    ex_klass = Class.new(ActiveRecord::Base)
+    assert_not ex_klass.included_modules.include? HasSluggedTitle
+    ex_klass.send(:include, HasSluggedTitle)
+    assert ex_klass.included_modules.include? HasSluggedTitle
+  end
+
+  test 'the concern adds a method #should_generate_new_friendly_id?' do
+    ex_klass = Class.new(ActiveRecord::Base)
+    assert_not ex_klass.instance_methods.include? :should_generate_new_friendly_id?
+    ex_klass.send(:include, HasSluggedTitle)
+    assert ex_klass.instance_methods.include? :should_generate_new_friendly_id?
+  end
+end


### PR DESCRIPTION
Hi Vlatka,
Here is a quick example of how you can use Rails concerns with ActiveRecord models to reduce code repetition.

Have fun!